### PR TITLE
Fix issues with Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ The `component_layout_plugin.py` file needs to be located into the KiCad script 
 example, on linux, it could go in `~/.kicad/scripting`. Once there, the script should be available
 to run in KiCad under 'Tools -> External Pluging'.
 
+For Windows:
+
+The Windows version of KiCad packages its own internal copy of Python 2.7. To install the required YAML dependency, open a command prompt as administrator and type:
+
+```
+"C:\Program Files\KiCad\bin\python.exe" -m pip install pyyaml==5.2
+```
+
 ## How to use
 
 When run in pcbnew, the plugin reads information about how to position components on the board from

--- a/component_layout_plugin.py
+++ b/component_layout_plugin.py
@@ -67,7 +67,7 @@ class ComponentLayout(pcbnew.ActionPlugin):
             logger.removeHandler(logger.handlers[0])
         logger.addHandler(filehandler)
 
-        logger.info(f'Logging to {os.path.join(projdir, "component_layout_plugin.log")}...')
+        logger.info('Logging to {}...'.format(os.path.join(projdir, "component_layout_plugin.log")))
         
         with open(os.path.join(projdir, 'layout.yaml')) as f:
             layout = yaml.load(f.read())
@@ -96,7 +96,7 @@ class ComponentLayout(pcbnew.ActionPlugin):
         for refdes, props in layout.get('components', {}).items():
             mod = pcb.FindModuleByReference(refdes)
             if mod is None:
-                logger.warning(f"Did not find component {refdes} in PCB design")
+                logger.warning("Did not find component {} in PCB design".format(refdes))
                 continue
             
             flip = props.get('flip', False) # Generally, flip means put on the bottom
@@ -120,7 +120,7 @@ class ComponentLayout(pcbnew.ActionPlugin):
 
                     newmod = pcbnew.FootprintLoad(footprint_path, footprint_name)
                     if newmod is None:
-                        logging.error(f"Failed to load footprint {footprint_name} from {footprint_path}")
+                        logging.error("Failed to load footprint {} from {}".format(footprint_name, footprint_path))
                         raise RuntimeError("Failed to load footprint %s from %s" % (footprint_name, footprint_path))
                     pcb.Delete(mod)
 


### PR DESCRIPTION
Windows KiCad is weird and awful and requires a prepackaged version of Python 2.7.

The changes are twofold: Remove the Python 3 only string formatters, and add installation instructions for an older version of YAML that supports the deprecated version of Python.